### PR TITLE
Pin Hugo version

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: 'latest'
+          hugo-version: '0.92.2'
           # extended: true
 
       - name: Build


### PR DESCRIPTION
As per title, pin Hugo version to the version 0.92.2

Related: https://github.com/halogenica/beautifulhugo/issues/423